### PR TITLE
Add makefile: clean, test and coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+clean:
+	rm coverage.out
+
+test:
+	go test -cover ./...
+
+coverage:
+	go test -coverprofile=coverage.out ./...
+	go tool cover -html=coverage.out


### PR DESCRIPTION
Adding Makefile to run test and coverage more simpler
- `Make clean` to clean all the resources created while development
- `Make test` runs unit tests
- `Make coverage` export test coverage into `coverage.out` and then open browser to see that coverage file in "human-friendly-format".