### PR TITLE
AN-103: Update event logger library to remove IAM sdk dependency

### DIFF
--- a/pkg/logger/event/README.md
+++ b/pkg/logger/event/README.md
@@ -14,7 +14,7 @@ import "github.com/AccelByte/go-restful-plugins/pkg/logger/event"
 
 ```go
 ws := new(restful.WebService)
-ws.Filter(event.Log("realm"))
+ws.Filter(event.Log("realm", event.ExtractNull))
 ```
 
 ### Log specific endpoint
@@ -22,14 +22,60 @@ ws.Filter(event.Log("realm"))
 ```go
 ws := new(restful.WebService)
 ws.Route(ws.GET("/user/{id}").
-    Filter(event.Log("realm")).
+    Filter(event.Log("realm", event.ExtractNull)).
     To(func(request *restful.Request, response *restful.Response) {
 }))
 ```
 
 ### Actor User ID & Namespace
 
-By default the logger will try to read `iam.JWTClaims` from the `restful.Request` to get the actor's user ID and namespace
+If you are using [IAM Auth Filter](https://github.com/AccelByte/go-restful-plugins/tree/master/pkg/auth/iam), 
+you can use this `extractFunc` for extracting `iam.JWTClaims` from the `restful.Request` to get the actor's user ID 
+and namespace.
+```go
+extractFunc := func(req *restful.Request) (userID string, clientID string, namespace string) {
+    claims := iam.RetrieveJWTClaims(req)
+    if claims != nil {
+        return claims.Subject, claims.Audience, claims.Namespace
+    }
+    return "", "", ""
+}
+```
+
+However, if you are using your own auth filter, you need to set the attributes to the request when registering the 
+route and you need to implement your custom extractFunc as well. For example:
+
+Set the attributes to the request in the auth filter function 
+```go
+// get token
+token := parseToken(request)
+
+// parse the JWT claims
+claims := parseClaim(token)
+
+// set the request attribute with claims
+request.SetAttribute("userID", claims.Audience)
+request.SetAttribute("clientID", claims.Subject)
+request.SetAttribute("namespace", claims.Namespace)
+```
+
+The logging filter function 
+```go
+extractFunc := func(req *restful.Request) (userID string, clientID string, namespace string){
+	userID, _ = req.Attribute("userID").(string)
+	clientID, _ = req.Attribute("clientID").(string)
+	namespace, _ = req.Attribute("namespace").(string)
+	
+	return userID, clientID, namespace
+}
+
+ws := new(restful.WebService)
+ws.Route(ws.GET("/user/{id}").
+    Filter(event.Log("realm", extractFunc)).
+    To(func(request *restful.Request, response *restful.Response) {
+}))
+```
+
 
 ### Target User ID & Namespace
 


### PR DESCRIPTION
Previously the library depends on IAM sdk package to get the userID,
clientID, and namespace. In this commit, we remove the dependency
so that service which doesn't use IAM sdk can use this library.
We need to define our own extraction function to get the userID,
clietnID, and namespace.