### PR TITLE
Export Trace `TraceIDKey` and Session `SessionIDKey` request header c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+Release v2.0.1 (2019-04-26)
+===========================
+- Export Trace `TraceIDKey` and Session `SessionIDKey` request header constants publicly
+
 Release v2.0.0 (2019-04-24)
 ===========================
 ### BREAKING CHANGES

--- a/pkg/logger/event/event.go
+++ b/pkg/logger/event/event.go
@@ -26,8 +26,8 @@ const (
 	eventLogAttribute     = "EventLog"
 	millisecondTimeFormat = "2006-01-02T15:04:05.999Z07:00"
 	logType               = "event"
-	traceIDKey            = "X-Ab-TraceID"
-	sessionIDKey          = "X-Ab-SessionID"
+	TraceIDKey            = "X-Ab-TraceID"
+	SessionIDKey          = "X-Ab-SessionID"
 )
 
 type event struct {
@@ -60,7 +60,7 @@ type extractAttribute func(req *restful.Request) (userID string, clientID []stri
 // extractNull is null function for extracting attribute
 var extractNull extractAttribute = func(req *restful.Request) (userID string, clientID []string, namespace string,
 	traceID string, sessionID string) {
-	return "", []string{}, "", req.HeaderParameter(traceIDKey), req.HeaderParameter(sessionIDKey)
+	return "", []string{}, "", req.HeaderParameter(TraceIDKey), req.HeaderParameter(SessionIDKey)
 }
 
 func init() {

--- a/pkg/logger/event/event_test.go
+++ b/pkg/logger/event/event_test.go
@@ -58,8 +58,8 @@ func TestInfoLog(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/namespace/abc/user/def", nil)
 	req.Header.Set("X-Forwarded-For", "8.8.8.8")
-	req.Header.Set(traceIDKey, "123456789")
-	req.Header.Set(sessionIDKey, "11223344")
+	req.Header.Set(TraceIDKey, "123456789")
+	req.Header.Set(SessionIDKey, "11223344")
 
 	resp := httptest.NewRecorder()
 	container.ServeHTTP(resp, req)
@@ -259,9 +259,9 @@ func TestInfoLogWithJWTClaims(t *testing.T) {
 		claims := iamAuth.RetrieveJWTClaims(req)
 		if claims != nil {
 			return claims.Subject, claims.Audience, claims.Namespace,
-				req.HeaderParameter(traceIDKey), req.HeaderParameter(sessionIDKey)
+				req.HeaderParameter(TraceIDKey), req.HeaderParameter(SessionIDKey)
 		}
-		return "", []string{}, "", req.HeaderParameter(traceIDKey), req.HeaderParameter(sessionIDKey)
+		return "", []string{}, "", req.HeaderParameter(TraceIDKey), req.HeaderParameter(SessionIDKey)
 	}
 	ws.Filter(Log("test", "iam", extract))
 


### PR DESCRIPTION
…onstants publicly