### PR TITLE
In 443 implement public source ip in common logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+Release v3.1.1 (2019-10-21)
+===========================
+- Update ip extraction on `logger/common` package
+
+Release v3.1.0 (2019-10-18)
+===========================
+- Add `trace` package
+- Update `response` package for Error Code Standards
+- Update ExtractDefault in `util` package
+
 Release v3.0.9 (2019-10-02)
 ===========================
 - Update `iam-go-sdk` to v1.1.2

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/AccelByte/go-jose v2.1.4+incompatible
 	github.com/AccelByte/iam-go-sdk v1.1.2
+	github.com/AccelByte/public-source-ip v1.0.0
 	github.com/emicklei/go-restful v2.9.3+incompatible
 	github.com/fatih/structs v1.1.0
 	github.com/google/uuid v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/AccelByte/go-jose v2.1.4+incompatible h1:jn3BJ0HZAUskWJ042CJGgFXDAwhT
 github.com/AccelByte/go-jose v2.1.4+incompatible/go.mod h1:X9vkgMrcPILJ7qhUruCaKHnslOhBTTpsC5DjiFpmmSc=
 github.com/AccelByte/iam-go-sdk v1.1.2 h1:LhmzKaXAsedI4BVLVmYtDTIsDcc+d51vP2CZ9aVowkI=
 github.com/AccelByte/iam-go-sdk v1.1.2/go.mod h1:M1Eplqpph/Msxm7XKgZRI+cYBCCChFdgPiVdKYupwq8=
+github.com/AccelByte/public-source-ip v1.0.0 h1:S/CeuU4cpejCexb2hUps9mYZ8BbqPeIWC27HyDI0ajQ=
+github.com/AccelByte/public-source-ip v1.0.0/go.mod h1:L7zIgt3UaXkGH7NoKFCbxPdWZOVwn+d6uW/5yYRXtnQ=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/logger/common/common.go
+++ b/pkg/logger/common/common.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 AccelByte Inc
+ * Copyright 2018-2019 AccelByte Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,10 @@
 package common
 
 import (
-	"strings"
+	"net/http"
 	"time"
 
+	publicsourceip "github.com/AccelByte/public-source-ip"
 	"github.com/emicklei/go-restful"
 	"github.com/sirupsen/logrus"
 )
@@ -34,7 +35,7 @@ func Log(req *restful.Request, resp *restful.Response, chain *restful.FilterChai
 	}
 	chain.ProcessFilter(req, resp)
 	logrus.Infof(`%s - %s [%s] "%s %s %s" %d %d`,
-		strings.Split(req.Request.RemoteAddr, ":")[0],
+		publicsourceip.PublicIP(&http.Request{Header: req.Request.Header}),
 		username,
 		time.Now().Format("02/Jan/2006:15:04:05 -0700"),
 		req.Request.Method,


### PR DESCRIPTION
### Implement public sourceIP in common logger

We have source ip address in common logger, but the logged ip is not IP address of the http call requester, but it shows the ip address of cluster ip address.
We need it to show the requester IP address.

@anggorodewanto @thoriqsatriya @fadhillahentino @rjjatson @hvlcrs @yani-satwib
