### PR TITLE
chore: access log format contains logrus field when printed to stdout

### DIFF
--- a/pkg/logger/common/README.md
+++ b/pkg/logger/common/README.md
@@ -34,3 +34,7 @@ Enable full access log mode. Default: false.
 #### FULL_ACCESS_LOG_SUPPORTED_CONTENT_TYPES
 Supported content types to shown in request_body and response_body log.
 Default: application/json,application/xml,application/x-www-form-urlencoded,text/plain,text/html.
+
+#### FULL_ACCESS_LOG_MAX_BODY_SIZE
+Maximum size of request body or response body that will be processed, will be ignored if exceed more than it.
+Default: 10240 bytes

--- a/pkg/logger/common/common.go
+++ b/pkg/logger/common/common.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -58,14 +59,13 @@ func init() {
 		FullAccessLogSupportedContentTypes = []string{"application/json", "application/xml", "application/x-www-form-urlencoded", "text/plain", "text/html"}
 	}
 
+	FullAccessLogMaxBodySize = 10 << 10 // 10KB
 	if s, exists := os.LookupEnv("FULL_ACCESS_LOG_MAX_BODY_SIZE"); exists {
 		value, err := strconv.ParseInt(s, 0, 64)
 		if err != nil {
 			logrus.Errorf("Parse FULL_ACCESS_LOG_MAX_BODY_SIZE env error: %v", err)
 		}
 		FullAccessLogMaxBodySize = int(value)
-	} else {
-		FullAccessLogMaxBodySize = 1 << 20 // 1MB
 	}
 }
 
@@ -92,7 +92,7 @@ func simpleAccessLogFilter(req *restful.Request, resp *restful.Response, chain *
 	chain.ProcessFilter(req, resp)
 
 	duration := time.Since(start)
-	logrus.Infof(commonLogFormat,
+	fmt.Println(fmt.Sprintf(commonLogFormat,
 		publicsourceip.PublicIP(&http.Request{Header: req.Request.Header}),
 		username,
 		time.Now().Format("02/Jan/2006:15:04:05 -0700"),
@@ -102,7 +102,7 @@ func simpleAccessLogFilter(req *restful.Request, resp *restful.Response, chain *
 		resp.StatusCode(),
 		resp.ContentLength(),
 		duration.Milliseconds(),
-	)
+	))
 }
 
 // fullAccessLogFilter will print the access log in complete log format
@@ -134,7 +134,7 @@ func fullAccessLogFilter(req *restful.Request, resp *restful.Response, chain *re
 
 	duration := time.Since(start)
 
-	logrus.Infof(fullAccessLogFormat,
+	fmt.Println(fmt.Sprintf(fullAccessLogFormat,
 		time.Now().Format("2006-01-02T15:04:05.000Z"),
 		req.Request.Method,
 		req.Request.URL.RequestURI(),
@@ -152,7 +152,7 @@ func fullAccessLogFilter(req *restful.Request, resp *restful.Response, chain *re
 		requestBody,
 		responseContentType,
 		responseBody,
-	)
+	))
 }
 
 // getRequestBody will get the request body from Request object

--- a/pkg/logger/common/common.go
+++ b/pkg/logger/common/common.go
@@ -92,7 +92,7 @@ func simpleAccessLogFilter(req *restful.Request, resp *restful.Response, chain *
 	chain.ProcessFilter(req, resp)
 
 	duration := time.Since(start)
-	fmt.Println(fmt.Sprintf(commonLogFormat,
+	logrus.Infof(fmt.Sprintf(commonLogFormat,
 		publicsourceip.PublicIP(&http.Request{Header: req.Request.Header}),
 		username,
 		time.Now().Format("02/Jan/2006:15:04:05 -0700"),
@@ -135,7 +135,7 @@ func fullAccessLogFilter(req *restful.Request, resp *restful.Response, chain *re
 	duration := time.Since(start)
 
 	fmt.Println(fmt.Sprintf(fullAccessLogFormat,
-		time.Now().Format("2006-01-02T15:04:05.000Z"),
+		time.Now().UTC().Format("2006-01-02T15:04:05.000Z"),
 		req.Request.Method,
 		req.Request.URL.RequestURI(),
 		resp.StatusCode(),

--- a/pkg/trace/README.md
+++ b/pkg/trace/README.md
@@ -16,7 +16,6 @@ Filter is restful.FilterFunction for generating traceID (X-Ab-TraceID header fie
 
 #### Example usage of filter for all endpoints
 
-#### Example usage of filter for all endpoints
 Simple initialization:
 ```go
 ws := new(restful.WebService)


### PR DESCRIPTION
We can't collect the golang services access logs since the format contains logrus fields

Example Current format:

`time="2021-09-02T01:28:20.236Z" level=info msg="THIS IS ACCESS_LOG"
`

Desired format that we need:
`THIS IS ACCESS_LOG`

Other reason: Logrus is using mutex when printing the logs. It's not scalable as it will block the other thread.