### PR TITLE
feat: Functionality to mask sensitive field(s) in query params, request body and response body before it printed as a log

### DIFF
--- a/pkg/logger/common/README.md
+++ b/pkg/logger/common/README.md
@@ -1,6 +1,6 @@
 # Common Log Format Logger
 
-This package enables logging using Common Log Format in go-restful apps.
+This package enables logging in go-restful apps.
 
 ## Usage
 
@@ -27,14 +27,41 @@ ws.Route(ws.GET("/user/{id}").
 }))
 ```
 
-### Environment variables
-#### FULL_ACCESS_LOG_ENABLED
-Enable full access log mode. Default: false.
+### Full access log mode
 
-#### FULL_ACCESS_LOG_SUPPORTED_CONTENT_TYPES
-Supported content types to shown in request_body and response_body log.
-Default: application/json,application/xml,application/x-www-form-urlencoded,text/plain,text/html.
+Full access log mode is used to view the full body detail of all request and response in the endpoints.
 
-#### FULL_ACCESS_LOG_MAX_BODY_SIZE
-Maximum size of request body or response body that will be processed, will be ignored if exceed more than it.
-Default: 10240 bytes
+#### Environment variables
+
+- **FULL_ACCESS_LOG_ENABLED**
+
+  Enable full access log mode. Default: `false`
+
+- **FULL_ACCESS_LOG_SUPPORTED_CONTENT_TYPES**
+
+  Supported content types to shown in request_body and response_body log.
+  Default: `application/json,application/xml,application/x-www-form-urlencoded,text/plain,text/html`
+
+- **FULL_ACCESS_LOG_MAX_BODY_SIZE**
+
+  Maximum size of request body or response body that will be processed, will be ignored if exceed more than it. Default: `10240` bytes
+
+#### Filter sensitive field(s) in request body or response body
+
+Some endpoint might have sensitive field value in its query params, request body or response body.
+For security reason, those sensitive field value should be masked before it printed as a log.
+
+The `log.Attribute` filter can be used to define the field(s) that need to be masked.
+
+```go
+ws := new(restful.WebService)
+ws.Route(ws.GET("/user/{id}").
+    Filter(common.Log).
+    Filter(log.Attribute(log.Option{
+        MaskedQueryParams: "param1,param2",
+        MaskedRequestFields: "field1,field2",
+        MaskedResponseFields: "field3,field4",
+    })).
+    To(func(request *restful.Request, response *restful.Response) {
+}))
+```

--- a/pkg/logger/log/log.go
+++ b/pkg/logger/log/log.go
@@ -1,0 +1,49 @@
+// Copyright 2022 AccelByte Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"github.com/emicklei/go-restful/v3"
+)
+
+const MaskedQueryParams = "MaskedQueryParams"
+const MaskedRequestFields = "MaskedRequestFields"
+const MaskedResponseFields = "MaskedResponseFields"
+
+// Option contains attribute options for log functionality
+type Option struct {
+	// Query param that need to masked in url, separated with comma
+	MaskedQueryParams string
+	// Field that need to masked in request body, separated with comma
+	MaskedRequestFields string
+	// Field that need to masked in response body, separated with comma
+	MaskedResponseFields string
+}
+
+// Attribute filter is used to define the log attribute for the endpoint.
+func Attribute(option Option) restful.FilterFunction {
+	return func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+		if option.MaskedQueryParams != "" {
+			req.SetAttribute(MaskedQueryParams, option.MaskedQueryParams)
+		}
+		if option.MaskedRequestFields != "" {
+			req.SetAttribute(MaskedRequestFields, option.MaskedRequestFields)
+		}
+		if option.MaskedResponseFields != "" {
+			req.SetAttribute(MaskedResponseFields, option.MaskedResponseFields)
+		}
+		chain.ProcessFilter(req, resp)
+	}
+}

--- a/pkg/logger/log/maskutil.go
+++ b/pkg/logger/log/maskutil.go
@@ -1,0 +1,102 @@
+// Copyright 2022 AccelByte Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+var FieldRegexCache = sync.Map{}
+
+const (
+	MaskedValue = "******"
+)
+
+// FieldRegex contains regex patterns for field name in varied content-types.
+type FieldRegex struct {
+	FieldName          string
+	JsonPattern        *regexp.Regexp
+	QueryStringPattern *regexp.Regexp
+}
+
+// InitFieldRegex initialize the FieldRegex along with its regex patterns.
+func (f *FieldRegex) InitFieldRegex(fieldName string) {
+	f.FieldName = fieldName
+	// "fieldName":"(.*?)"
+	f.JsonPattern = regexp.MustCompile(fmt.Sprintf("\"%s\":\"(.*?)\"", fieldName))
+	// fieldName=(.*?[^&]*)|fieldName=(.*?)$
+	f.QueryStringPattern = regexp.MustCompile(fmt.Sprintf("%s=(.*?[^&]*)|%s=(.*?)$", fieldName, fieldName))
+}
+
+// MaskFields will mask the field value on the content string based on the
+// provided field name(s) in "fields" parameter separated by comma.
+func MaskFields(contentType, content, fields string) string {
+	if content == "" || fields == "" {
+		return content
+	}
+
+	fieldNames := strings.Split(fields, ",")
+	for _, fieldName := range fieldNames {
+		var fieldRegex FieldRegex
+		if val, ok := FieldRegexCache.Load(fieldName); ok {
+			fieldRegex = val.(FieldRegex)
+		} else {
+			fieldRegex = FieldRegex{}
+			fieldRegex.InitFieldRegex(fieldName)
+			FieldRegexCache.Store(fieldName, fieldRegex)
+		}
+
+		if strings.Contains(contentType, "application/json") {
+			content = fieldRegex.JsonPattern.ReplaceAllString(content, fmt.Sprintf("\"%s\":\"%s\"", fieldName, MaskedValue))
+		} else if strings.Contains(contentType, "application/x-www-form-urlencoded") {
+			content = fieldRegex.QueryStringPattern.ReplaceAllString(content, fmt.Sprintf("%s=%s", fieldName, MaskedValue))
+		} else {
+			// try json pattern and form-data pattern
+			if fieldRegex.JsonPattern.MatchString(content) {
+				content = fieldRegex.JsonPattern.ReplaceAllString(content, fmt.Sprintf("\"%s\":\"%s\"", fieldName, MaskedValue))
+			} else if fieldRegex.QueryStringPattern.MatchString(content) {
+				content = fieldRegex.QueryStringPattern.ReplaceAllString(content, fmt.Sprintf("%s=%s", fieldName, MaskedValue))
+			}
+		}
+	}
+
+	return content
+}
+
+// MaskQueryParams will mask the field value on the uri based on the
+// provided field name(s) in "fields" parameter separated by comma.
+func MaskQueryParams(uri string, fields string) string {
+	if uri == "" || fields == "" {
+		return uri
+	}
+
+	fieldNames := strings.Split(fields, ",")
+	for _, fieldName := range fieldNames {
+		var fieldRegex FieldRegex
+		if val, ok := FieldRegexCache.Load(fieldName); ok {
+			fieldRegex = val.(FieldRegex)
+		} else {
+			fieldRegex = FieldRegex{}
+			fieldRegex.InitFieldRegex(fieldName)
+			FieldRegexCache.Store(fieldName, fieldRegex)
+		}
+
+		uri = fieldRegex.QueryStringPattern.ReplaceAllString(uri, fmt.Sprintf("%s=%s", fieldName, MaskedValue))
+	}
+	return uri
+}

--- a/pkg/logger/log/maskutil_test.go
+++ b/pkg/logger/log/maskutil_test.go
@@ -1,0 +1,396 @@
+// Copyright 2022 AccelByte Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMaskSingleField(t *testing.T) {
+	t.Parallel()
+
+	inputAndExpected := [][]string{
+		// Content-Type = application/json
+		{
+			"application/json",                 // content-type
+			"{\"password\":\"mypassword123\"}", // input
+			"{\"password\":\"******\"}",        // expected
+		},
+		{
+			"application/json",
+			"{\"username\":\"my username\",\"password\":\"mypassword123\"}",
+			"{\"username\":\"my username\",\"password\":\"******\"}",
+		},
+		{
+			"application/json",
+			"{\"username\":\"my username\",\"password\":\"mypassword123\",\"displayName\":\"My Display Name\"}",
+			"{\"username\":\"my username\",\"password\":\"******\",\"displayName\":\"My Display Name\"}",
+		},
+		{
+			"application/json",
+			"{\"displayName\":\"My Display Name\",\"secret\":{\"username\":\"my username\",\"password\":\"mypassword123\"}}",
+			"{\"displayName\":\"My Display Name\",\"secret\":{\"username\":\"my username\",\"password\":\"******\"}}",
+		},
+		// Content-Type = application/x-www-form-urlencoded
+		{
+			"application/x-www-form-urlencoded",
+			"password=mypassword",
+			"password=******",
+		},
+		{
+			"application/x-www-form-urlencoded",
+			"username=my username&password=my password",
+			"username=my username&password=******",
+		},
+		{
+			"application/x-www-form-urlencoded",
+			"username=my username&password=my password&displayName=My Display Name",
+			"username=my username&password=******&displayName=My Display Name",
+		},
+		// Content-Type = plain/text
+		{
+			"plain/text",
+			"{\"username\":\"my username\",\"password\":\"mypassword123\",\"displayName\":\"My Display Name\"}",
+			"{\"username\":\"my username\",\"password\":\"******\",\"displayName\":\"My Display Name\"}",
+		},
+		{
+			"plain/text",
+			"username=my username&password=mypassword&displayName=My Display Name",
+			"username=my username&password=******&displayName=My Display Name",
+		},
+	}
+
+	for _, val := range inputAndExpected {
+		assert.Equal(t, val[2], MaskFields(val[0], val[1], "password"))
+	}
+}
+
+func TestMaskMultipleFields(t *testing.T) {
+	t.Parallel()
+
+	inputAndExpected := [][]string{
+		// Content-Type = application/json
+		{
+			"application/json",                 // content-type
+			"{\"password\":\"mypassword123\"}", // input
+			"{\"password\":\"******\"}",        // expected
+		},
+		{
+			"application/json",
+			"{\"username\":\"my username\",\"password\":\"mypassword123\"}",
+			"{\"username\":\"******\",\"password\":\"******\"}",
+		},
+		{
+			"application/json",
+			"{\"username\":\"my username\",\"password\":\"mypassword123\",\"displayName\":\"My Display Name\"}",
+			"{\"username\":\"******\",\"password\":\"******\",\"displayName\":\"My Display Name\"}",
+		},
+		{
+			"application/json",
+			"{\"displayName\":\"My Display Name\",\"secret\":{\"username\":\"my username\",\"password\":\"mypassword123\"}}",
+			"{\"displayName\":\"My Display Name\",\"secret\":{\"username\":\"******\",\"password\":\"******\"}}",
+		},
+		// Content-Type = application/x-www-form-urlencoded
+		{
+			"application/x-www-form-urlencoded",
+			"password=mypassword",
+			"password=******",
+		},
+		{
+			"application/x-www-form-urlencoded",
+			"username=my username&password=my password",
+			"username=******&password=******",
+		},
+		{
+			"application/x-www-form-urlencoded",
+			"username=my username&password=my password&displayName=My Display Name",
+			"username=******&password=******&displayName=My Display Name",
+		},
+		// Content-Type = plain/text
+		{
+			"plain/text",
+			"{\"username\":\"my username\",\"password\":\"mypassword123\",\"displayName\":\"My Display Name\"}",
+			"{\"username\":\"******\",\"password\":\"******\",\"displayName\":\"My Display Name\"}",
+		},
+		{
+			"plain/text",
+			"username=my username&password=mypassword&displayName=My Display Name",
+			"username=******&password=******&displayName=My Display Name",
+		},
+	}
+
+	for _, val := range inputAndExpected {
+		assert.Equal(t, val[2], MaskFields(val[0], val[1], "username,password"))
+	}
+}
+
+func TestMaskMultipleFields_ButOneFieldIsNotExist(t *testing.T) {
+	t.Parallel()
+
+	inputAndExpected := [][]string{
+		// Content-Type = application/json
+		{
+			"application/json",                 // content-type
+			"{\"password\":\"mypassword123\"}", // input
+			"{\"password\":\"******\"}",        // expected
+		},
+		{
+			"application/json",
+			"{\"username\":\"my username\",\"password\":\"mypassword123\"}",
+			"{\"username\":\"my username\",\"password\":\"******\"}",
+		},
+		// Content-Type = application/x-www-form-urlencoded
+		{
+			"application/x-www-form-urlencoded",
+			"password=mypassword",
+			"password=******",
+		},
+		{
+			"application/x-www-form-urlencoded",
+			"username=my username&password=my password",
+			"username=my username&password=******",
+		},
+		// Content-Type = plain/text
+		{
+			"plain/text",
+			"{\"username\":\"my username\",\"password\":\"mypassword123\",\"displayName\":\"My Display Name\"}",
+			"{\"username\":\"my username\",\"password\":\"******\",\"displayName\":\"My Display Name\"}",
+		},
+		{
+			"plain/text",
+			"username=my username&password=mypassword&displayName=My Display Name",
+			"username=my username&password=******&displayName=My Display Name",
+		},
+	}
+
+	for _, val := range inputAndExpected {
+		assert.Equal(t, val[2], MaskFields(val[0], val[1], "password,apiKey"))
+	}
+}
+
+func TestMaskField_ButNoneFieldIsExist(t *testing.T) {
+	t.Parallel()
+
+	inputAndExpected := [][]string{
+		// Content-Type = application/json
+		{
+			"application/json",                      // content-type
+			"{\"displayName\":\"My Display Name\"}", // input
+			"{\"displayName\":\"My Display Name\"}", // expected
+		},
+		// Content-Type = application/x-www-form-urlencoded
+		{
+			"application/x-www-form-urlencoded",
+			"displayName=My Display Name",
+			"displayName=My Display Name",
+		},
+		// Content-Type = plain/text
+		{
+			"plain/text",
+			"{\"displayName\":\"My Display Name\"}",
+			"{\"displayName\":\"My Display Name\"}",
+		},
+		{
+			"plain/text",
+			"displayName=My Display Name",
+			"displayName=My Display Name",
+		},
+	}
+
+	for _, val := range inputAndExpected {
+		assert.Equal(t, val[2], MaskFields(val[0], val[1], "password,apiKey"))
+	}
+}
+
+func TestMaskField_ConcurrentCall(t *testing.T) {
+	t.Parallel()
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		input := "{\"password\":\"mypassword123\"}"
+		expected := "{\"password\":\"******\"}"
+		i := 0
+		for i < 1000 {
+			assert.Equal(t, expected, MaskFields("application/json", input, "password"))
+			i++
+		}
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		input := "{\"token\":\"my token 123\"}"
+		expected := "{\"token\":\"******\"}"
+
+		i := 0
+		for i < 1000 {
+			assert.Equal(t, expected, MaskFields("application/json", input, "token"))
+			i++
+		}
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		input := "apikey=my api key"
+		expected := "apikey=******"
+
+		i := 0
+		for i < 1000 {
+			assert.Equal(t, expected, MaskFields("application/x-www-form-urlencoded", input, "apikey"))
+			i++
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+}
+
+func TestMaskSingleQueryParam(t *testing.T) {
+	t.Parallel()
+
+	inputAndExpected := [][]string{
+		{
+			"https://example.net", // input
+			"https://example.net", // expected
+		},
+		{
+			"https://example.net?password=mypassword123",
+			"https://example.net?password=******",
+		},
+		{
+			"https://example.net?username=myusername&password=mypassword123",
+			"https://example.net?username=myusername&password=******",
+		},
+		{
+			"https://example.net?username=my username&password=mypassword 123",
+			"https://example.net?username=my username&password=******",
+		},
+		{
+			"https://example.net?username=my username&password=mypassword 123&displayName=My Display Name",
+			"https://example.net?username=my username&password=******&displayName=My Display Name",
+		},
+		{
+			"127.0.0.1?password=mypassword123",
+			"127.0.0.1?password=******",
+		},
+		{
+			"https://subdomain.example.net?password=mypassword123",
+			"https://subdomain.example.net?password=******",
+		},
+	}
+
+	for _, val := range inputAndExpected {
+		assert.Equal(t, val[1], MaskQueryParams(val[0], "password"))
+	}
+}
+
+func TestMaskMultipleQueryParams(t *testing.T) {
+	t.Parallel()
+
+	inputAndExpected := [][]string{
+		{
+			"https://example.net?password=mypassword123", // input
+			"https://example.net?password=******",        // expected
+		},
+		{
+			"https://example.net?username=myusername&password=mypassword123",
+			"https://example.net?username=******&password=******",
+		},
+		{
+			"https://example.net?username=my username&password=mypassword 123",
+			"https://example.net?username=******&password=******",
+		},
+		{
+			"https://example.net?username=my username&password=mypassword 123&displayName=My Display Name",
+			"https://example.net?username=******&password=******&displayName=My Display Name",
+		},
+	}
+
+	for _, val := range inputAndExpected {
+		assert.Equal(t, val[1], MaskQueryParams(val[0], "username,password"))
+	}
+}
+
+func TestMaskQueryParamOfEncodedURLs(t *testing.T) {
+	t.Parallel()
+
+	inputAndExpected := [][]string{
+		{
+			"https://example.net?username=my%20username&password=mypassword%20123", // input
+			"https://example.net?username=******&password=******",                  // expected
+		},
+		{
+			"https://example.net?username=my%20username&password=mypassword%20123&displayName=My%20Display%20Name",
+			"https://example.net?username=******&password=******&displayName=My%20Display%20Name",
+		},
+		{
+			// https://example.net?openid.ns=http://specs.openid.net/auth/2.0&openid.mode=id_res&openid.identity=https://steamcommunity.com/openid/id/123456789&openid.signed=signed,op_endpoint,claimed_id,identity&openid.sig=dGhpc19pc19zaWc=
+			"https://example.net?openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&openid.mode=id_res&openid.identity=https%3A%2F%2Fsteamcommunity.com%2Fopenid%2Fid%2F123456789&openid.signed=signed%2Cop_endpoint%2Cclaimed_id%2Cidentity&openid.sig=dGhpc19pc19zaWc%3D",
+			"https://example.net?openid.ns=http%3A%2F%2Fspecs.openid.net%2Fauth%2F2.0&openid.mode=id_res&openid.identity=******&openid.signed=signed%2Cop_endpoint%2Cclaimed_id%2Cidentity&openid.sig=******",
+		},
+	}
+
+	for _, val := range inputAndExpected {
+		assert.Equal(t, val[1], MaskQueryParams(val[0], "username,password,openid.identity,openid.sig"))
+	}
+}
+
+func TestMaskQueryParam_ConcurrentCall(t *testing.T) {
+	t.Parallel()
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		input := "https://example.net?password=mypassword123"
+		expected := "https://example.net?password=******"
+		i := 0
+		for i < 1000 {
+			assert.Equal(t, expected, MaskQueryParams(input, "password"))
+			i++
+		}
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		input := "https://example.net?username=username"
+		expected := "https://example.net?username=******"
+		i := 0
+		for i < 1000 {
+			assert.Equal(t, expected, MaskQueryParams(input, "username"))
+			i++
+		}
+		wg.Done()
+	}()
+
+	wg.Add(1)
+	go func() {
+		input := "https://example.net?apiKey=apiKey"
+		expected := "https://example.net?apiKey=******"
+		i := 0
+		for i < 1000 {
+			assert.Equal(t, expected, MaskQueryParams(input, "apiKey"))
+			i++
+		}
+		wg.Done()
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
Some endpoint might have sensitive field value in its request body or response body.
For security reason, those sensitive field value should be masked before it printed as a log.

The `log.Attribute` filter can be used to define the field(s) that need to be masked.

```go
ws := new(restful.WebService)
ws.Route(ws.GET("/user/{id}").
    Filter(common.Log).
    Filter(log.Attribute(log.Option{
        MaskedQueryParams: "param1,param2",
        MaskedRequestFields: "field1,field2",
        MaskedResponseFields: "field3,field4",
    })).
    To(func(request *restful.Request, response *restful.Response) {
}))
```

https://accelbyte.atlassian.net/browse/CORE-5845