### PR TITLE
feat: Add CORS filter that support strict allowed-domain validation and fix Referer validation that allow referer with extra wrong domain

### DIFF
--- a/pkg/auth/iam/iam.go
+++ b/pkg/auth/iam/iam.go
@@ -352,6 +352,7 @@ func parseAccessToken(request *restful.Request) (string, string, error) {
 }
 
 // validateRefererHeader is used validate the referer header against client's redirectURIs.
+// we're not using Origin header since it will null for GET request.
 func (filter *Filter) validateRefererHeader(request *restful.Request, claims *iam.JWTClaims) bool {
 	clientInfo, err := filter.iamClient.GetClientInformation(claims.Namespace, claims.ClientID)
 	if err != nil {
@@ -362,25 +363,32 @@ func (filter *Filter) validateRefererHeader(request *restful.Request, claims *ia
 		return true
 	}
 
-	refererHeader := request.HeaderParameter(constant.Referer)
-	clientRedirectURIs := strings.Split(clientInfo.RedirectURI, ",")
-	for _, redirectURI := range clientRedirectURIs {
-		if !filter.options.StrictRefererHeaderValidation {
-			redirectURI = util.GetDomain(redirectURI)
-		}
-		if filter.options.AllowSubdomainMatchRefererHeaderValidation {
-			if validateRefererWithSubdomain(refererHeader, redirectURI) {
-				return true
-			}
-		} else {
-			if strings.HasPrefix(refererHeader, redirectURI) {
-				return true
+	referer := request.HeaderParameter(constant.Referer)
+	if referer != "" {
+		refererDomain := util.GetDomain(referer)
+		clientRedirectURIs := strings.Split(clientInfo.RedirectURI, ",")
+		for _, redirectURI := range clientRedirectURIs {
+			if filter.options.AllowSubdomainMatchRefererHeaderValidation {
+				if validateRefererWithSubdomain(referer, redirectURI) {
+					return true
+				}
+			} else {
+				redirectURIDomain := util.GetDomain(redirectURI)
+				if filter.options.StrictRefererHeaderValidation {
+					if refererDomain == redirectURIDomain && strings.HasPrefix(referer, redirectURI) {
+						return true
+					}
+				} else {
+					if refererDomain == redirectURIDomain {
+						return true
+					}
+				}
 			}
 		}
 	}
 
 	logrus.Warnf("request has invalid referer header. referer header: %s. client redirect uri: %s",
-		refererHeader, clientInfo.RedirectURI)
+		referer, clientInfo.RedirectURI)
 	return false
 }
 

--- a/pkg/auth/iam/iam_test.go
+++ b/pkg/auth/iam/iam_test.go
@@ -64,6 +64,16 @@ func TestValidateRefererHeader_RedirectUriIsDomain(t *testing.T) {
 			allowed:       false,
 		},
 		{
+			name:          "wrong referer 4th",
+			refererHeader: "https://example.com",
+			allowed:       false,
+		},
+		{
+			name:          "wrong referer 5th",
+			refererHeader: "https://www.example.com:8080",
+			allowed:       false,
+		},
+		{
 			name:          "referer with extra wrong domain",
 			refererHeader: "https://www.example.com.something.net",
 			allowed:       false,
@@ -119,6 +129,11 @@ func TestValidateRefererHeader_RedirectUriIsIP(t *testing.T) {
 		{
 			name:          "wrong referer",
 			refererHeader: "http://127.0.0.2",
+			allowed:       false,
+		},
+		{
+			name:          "wrong referer 2nd",
+			refererHeader: "127.0.0.1",
 			allowed:       false,
 		},
 		{
@@ -188,6 +203,11 @@ func TestValidateRefererHeader_RedirectUriContainsPort(t *testing.T) {
 		{
 			name:          "wrong referer 3rd",
 			refererHeader: "https://www.wrong.com",
+			allowed:       false,
+		},
+		{
+			name:          "wrong referer 4th",
+			refererHeader: "www.example.com:8080",
 			allowed:       false,
 		},
 		{
@@ -270,6 +290,18 @@ func TestValidateRefererHeader_ClientHaveMultipleRedirectURIs(t *testing.T) {
 			allowed:       false,
 		},
 		{
+			name:          "wrong referer 4th",
+			refererHeader: "www.example.com",
+			filter:        NewFilter(iamClientWithMultipleRedirectURI),
+			allowed:       false,
+		},
+		{
+			name:          "wrong referer 5th",
+			refererHeader: "https://www.example.com:8080",
+			filter:        NewFilter(iamClientWithMultipleRedirectURI),
+			allowed:       false,
+		},
+		{
 			name:          "referer with extra wrong domain",
 			refererHeader: "https://www.example.com.something.net",
 			filter:        NewFilter(iamClientWithMultipleRedirectURI),
@@ -342,6 +374,11 @@ func TestValidateRefererHeader_StrictRefererValidation(t *testing.T) {
 		{
 			name:          "wrong referer 3rd",
 			refererHeader: "https://www.wrong.com",
+			allowed:       false,
+		},
+		{
+			name:          "wrong referer 5th",
+			refererHeader: "https://www.example.com:8080/admin",
 			allowed:       false,
 		},
 		{

--- a/pkg/cors/cors_filter.go
+++ b/pkg/cors/cors_filter.go
@@ -1,0 +1,161 @@
+// Copyright 2022 AccelByte Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cors
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/sirupsen/logrus"
+)
+
+// CrossOriginResourceSharing is used to create a Container Filter that implements CORS.
+// Cross-origin resource sharing (CORS) is a mechanism that allows JavaScript on a web page
+// to make XMLHttpRequests to another domain, not the domain the JavaScript originated from.
+//
+// http://en.wikipedia.org/wiki/Cross-origin_resource_sharing
+// http://enable-cors.org/server.html
+// https://web.dev/cross-origin-resource-sharing
+type CrossOriginResourceSharing struct {
+	ExposeHeaders  []string // list of exposed Headers
+	AllowedHeaders []string // list of allowed Headers
+	AllowedDomains []string // list of allowed values for Http Origin. An allowed value can be a regular expression to support subdomain matching. If empty all are allowed.
+	AllowedMethods []string // list of allowed Methods
+	MaxAge         int      // number of seconds that indicates how long the results of a preflight request can be cached.
+	CookiesAllowed bool
+	Container      *restful.Container
+}
+
+// Filter is a filter function that implements the CORS flow
+func (c CrossOriginResourceSharing) Filter(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
+	origin := req.Request.Header.Get(restful.HEADER_Origin)
+	if len(origin) == 0 {
+		chain.ProcessFilter(req, resp)
+		return
+	}
+	if !c.isOriginAllowed(origin) { // check whether this origin is allowed
+		logrus.Debugf("HTTP Origin:%s is not part of %v", origin, c.AllowedDomains)
+		chain.ProcessFilter(req, resp)
+		return
+	}
+
+	if c.isPreflightRequest(req) {
+		c.doPreflightRequest(req, resp)
+		// return http 200 response, no body
+		return
+	}
+
+	c.setOptionsHeaders(req, resp)
+	chain.ProcessFilter(req, resp)
+}
+
+// isPreflightRequest will check if the request is a preflight request or not.
+func (c *CrossOriginResourceSharing) isPreflightRequest(req *restful.Request) bool {
+	if req.Request.Method == "OPTIONS" {
+		if acrm := req.Request.Header.Get(restful.HEADER_AccessControlRequestMethod); acrm != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// doPreflightRequest will set the necessary preflight headers into response header,
+// e.g. Access-Control-Allow-Methods, Access-Control-Allow-Headers, Access-Control-Max-Age and all the default options headers (see setOptionsHeaders func)
+func (c *CrossOriginResourceSharing) doPreflightRequest(req *restful.Request, resp *restful.Response) {
+	acrm := req.Request.Header.Get(restful.HEADER_AccessControlRequestMethod)
+	if !c.isValidAccessControlRequestMethod(acrm) {
+		logrus.Debugf("Http header %s:%s is not in %v",
+			restful.HEADER_AccessControlRequestMethod,
+			acrm,
+			c.AllowedMethods)
+		return
+	}
+	acrhs := req.Request.Header.Get(restful.HEADER_AccessControlRequestHeaders)
+	if len(acrhs) > 0 {
+		for _, each := range strings.Split(acrhs, ",") {
+			if !c.isValidAccessControlRequestHeader(strings.Trim(each, " ")) {
+				logrus.Debugf("Http header %s:%s is not in %v",
+					restful.HEADER_AccessControlRequestHeaders,
+					acrhs,
+					c.AllowedHeaders)
+				return
+			}
+		}
+	}
+	resp.AddHeader(restful.HEADER_AccessControlAllowMethods, strings.Join(c.AllowedMethods, ","))
+	resp.AddHeader(restful.HEADER_AccessControlAllowHeaders, acrhs)
+
+	if c.MaxAge > 0 {
+		resp.AddHeader(restful.HEADER_AccessControlMaxAge, strconv.Itoa(c.MaxAge))
+	}
+
+	c.setOptionsHeaders(req, resp)
+}
+
+// setOptionsHeaders will set option headers into response header,
+// e.g. Access-Control-Allow-Origin, Access-Control-Expose-Headers, Access-Control-Allow-Credentials
+func (c CrossOriginResourceSharing) setOptionsHeaders(req *restful.Request, resp *restful.Response) {
+	origin := req.Request.Header.Get(restful.HEADER_Origin)
+	resp.AddHeader(restful.HEADER_AccessControlAllowOrigin, origin)
+
+	// some reference said that "Access-Control-Expose-Headers" should only be set for Actual request's response header (not Preflight request),
+	// but we're keep it here to follow the current implementation from go-restful.
+	if len(c.ExposeHeaders) > 0 {
+		resp.AddHeader(restful.HEADER_AccessControlExposeHeaders, strings.Join(c.ExposeHeaders, ","))
+	}
+
+	if c.CookiesAllowed {
+		resp.AddHeader(restful.HEADER_AccessControlAllowCredentials, "true")
+	}
+}
+
+// isOriginAllowed will check if origin is allowed
+func (c CrossOriginResourceSharing) isOriginAllowed(origin string) bool {
+	if len(origin) == 0 {
+		return false
+	}
+	if len(c.AllowedDomains) == 0 {
+		return true
+	}
+
+	for _, domain := range c.AllowedDomains {
+		if domain == origin || domain == "*" {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isValidAccessControlRequestMethod will check if method is allowed
+func (c CrossOriginResourceSharing) isValidAccessControlRequestMethod(method string) bool {
+	for _, each := range c.AllowedMethods {
+		if each == method {
+			return true
+		}
+	}
+	return false
+}
+
+// isValidAccessControlRequestHeader will check if header is allowed
+func (c CrossOriginResourceSharing) isValidAccessControlRequestHeader(header string) bool {
+	for _, each := range c.AllowedHeaders {
+		if strings.ToLower(each) == strings.ToLower(header) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cors/cors_filter_test.go
+++ b/pkg/cors/cors_filter_test.go
@@ -1,0 +1,324 @@
+// Copyright 2022 AccelByte Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cors
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/emicklei/go-restful/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func createDummyRequest() *restful.Request {
+	return &restful.Request{
+		Request: &http.Request{
+			Header: map[string][]string{},
+		},
+	}
+}
+
+func createDummyResponse() *restful.Response {
+	httpWriter := httptest.NewRecorder()
+	response := &restful.Response{
+		ResponseWriter: httpWriter,
+	}
+
+	return response
+}
+
+func createDummyFilterChain() *restful.FilterChain {
+	return &restful.FilterChain{
+		Filters: make([]restful.FilterFunction, 0),
+		Target: func(req *restful.Request, resp *restful.Response) {
+			fmt.Println("[FilterChain] dummy target func invoked")
+		},
+	}
+}
+
+func TestIsOriginAllowed(t *testing.T) {
+	// TEST 1: Single allowed domain
+	cors := CrossOriginResourceSharing{
+		AllowedDomains: []string{"https://www.example.io"},
+	}
+	assert.True(t, cors.isOriginAllowed("https://www.example.io"))
+	assert.False(t, cors.isOriginAllowed("https://www.example.com"))
+	assert.False(t, cors.isOriginAllowed("https://www.example.io.something"))
+	assert.False(t, cors.isOriginAllowed("https://www.example.io.something.io"))
+
+	// TEST 2: IP domain
+	corsWithIPDomain := CrossOriginResourceSharing{
+		AllowedDomains: []string{"127.0.0.1"},
+	}
+	assert.True(t, corsWithIPDomain.isOriginAllowed("127.0.0.1"))
+	assert.False(t, corsWithIPDomain.isOriginAllowed("127.0.0.2"))
+	assert.False(t, corsWithIPDomain.isOriginAllowed("127.0.0.1.1"))
+	assert.False(t, corsWithIPDomain.isOriginAllowed("https://www.example.io"))
+	assert.False(t, corsWithIPDomain.isOriginAllowed("https://www.example.com"))
+	assert.False(t, corsWithIPDomain.isOriginAllowed("https://www.example.io.something"))
+	assert.False(t, corsWithIPDomain.isOriginAllowed("https://www.example.io.something.io"))
+
+	// TEST 3: Multiple allowed domains
+	corsWithMultipleAllowedDomain := CrossOriginResourceSharing{
+		AllowedDomains: []string{"https://www.example.io", "https://www.example.com", "127.0.0.1"},
+	}
+	assert.True(t, corsWithMultipleAllowedDomain.isOriginAllowed("https://www.example.io"))
+	assert.True(t, corsWithMultipleAllowedDomain.isOriginAllowed("https://www.example.com"))
+	assert.True(t, corsWithMultipleAllowedDomain.isOriginAllowed("127.0.0.1"))
+	assert.False(t, corsWithMultipleAllowedDomain.isOriginAllowed("https://www.example.io.something"))
+	assert.False(t, corsWithMultipleAllowedDomain.isOriginAllowed("https://www.example.io.something.io"))
+
+	// TEST 4: Allowed domain is wildcard
+	corsWithWildcardAllowedDomain := CrossOriginResourceSharing{
+		AllowedDomains: []string{"*"},
+	}
+	assert.True(t, corsWithWildcardAllowedDomain.isOriginAllowed("https://www.example.io"))
+	assert.True(t, corsWithWildcardAllowedDomain.isOriginAllowed("https://www.example.com"))
+	assert.True(t, corsWithWildcardAllowedDomain.isOriginAllowed("https://www.example.io.something"))
+	assert.True(t, corsWithWildcardAllowedDomain.isOriginAllowed("https://www.example.io.something.io"))
+
+}
+
+func TestIsValidAccessControlRequestMethod(t *testing.T) {
+	cors := CrossOriginResourceSharing{
+		AllowedMethods: []string{"GET", "POST"},
+	}
+	assert.True(t, cors.isValidAccessControlRequestMethod("GET"))
+	assert.True(t, cors.isValidAccessControlRequestMethod("POST"))
+	assert.False(t, cors.isValidAccessControlRequestMethod("DELETE"))
+}
+
+func TestIsValidAccessControlRequestHeader(t *testing.T) {
+	cors := CrossOriginResourceSharing{
+		AllowedHeaders: []string{"Content-Type", "Accept", "Device-Id"},
+	}
+	assert.True(t, cors.isValidAccessControlRequestHeader("Content-Type"))
+	assert.True(t, cors.isValidAccessControlRequestHeader("Accept"))
+	assert.False(t, cors.isValidAccessControlRequestHeader("Something"))
+}
+
+func TestPreflightRequest(t *testing.T) {
+	cors := CrossOriginResourceSharing{
+		AllowedMethods: []string{"GET", "POST"},
+		AllowedHeaders: []string{"Content-Type", "Accept", "Device-Id"},
+	}
+
+	// TEST 1: Success
+	req1 := createDummyRequest()
+	req1.Request.Header.Set("Access-Control-Request-Method", "GET")
+	req1.Request.Header.Set("Access-Control-Request-Headers", "Content-Type,Accept")
+	resp1 := createDummyResponse()
+	cors.doPreflightRequest(req1, resp1)
+
+	assert.NotEmpty(t, resp1.Header().Get("Access-Control-Allow-Methods"))
+	assert.NotEmpty(t, resp1.Header().Get("Access-Control-Allow-Headers"))
+	assert.Equal(t, "GET,POST", resp1.Header().Get("Access-Control-Allow-Methods"))
+	assert.Equal(t, "Content-Type,Accept", resp1.Header().Get("Access-Control-Allow-Headers"))
+
+	// TEST 2: Request Method not allowed
+	req2 := createDummyRequest()
+	req2.Request.Header.Set("Access-Control-Request-Method", "DELETE")
+	req2.Request.Header.Set("Access-Control-Request-Headers", "Content-Type,Accept")
+	resp2 := createDummyResponse()
+	cors.doPreflightRequest(req2, resp2)
+
+	assert.Empty(t, resp2.Header().Get("Access-Control-Allow-Methods"))
+	assert.Empty(t, resp2.Header().Get("Access-Control-Allow-Headers"))
+
+	// TEST 3: Request Header not allowed
+	req3 := createDummyRequest()
+	req3.Request.Header.Set("Access-Control-Request-Method", "GET")
+	req3.Request.Header.Set("Access-Control-Request-Headers", "Something")
+	resp3 := createDummyResponse()
+	cors.doPreflightRequest(req3, resp3)
+
+	assert.Empty(t, resp3.Header().Get("Access-Control-Allow-Methods"))
+	assert.Empty(t, resp3.Header().Get("Access-Control-Allow-Headers"))
+}
+
+func TestPreflightRequest_MaxAgeConfigured(t *testing.T) {
+	corsWithMaxAge := CrossOriginResourceSharing{
+		AllowedMethods: []string{"GET", "POST"},
+		AllowedHeaders: []string{"Content-Type", "Accept", "Device-Id"},
+		MaxAge:         3600,
+	}
+
+	// TEST 1: Success
+	req1 := createDummyRequest()
+	req1.Request.Header.Set("Access-Control-Request-Method", "GET")
+	req1.Request.Header.Set("Access-Control-Request-Headers", "Content-Type,Accept")
+	resp1 := createDummyResponse()
+
+	corsWithMaxAge.doPreflightRequest(req1, resp1)
+
+	assert.NotEmpty(t, resp1.Header().Get("Access-Control-Allow-Methods"))
+	assert.NotEmpty(t, resp1.Header().Get("Access-Control-Allow-Headers"))
+	assert.NotEmpty(t, resp1.Header().Get("Access-Control-Max-Age"))
+	assert.Equal(t, "GET,POST", resp1.Header().Get("Access-Control-Allow-Methods"))
+	assert.Equal(t, "Content-Type,Accept", resp1.Header().Get("Access-Control-Allow-Headers"))
+	assert.Equal(t, "3600", resp1.Header().Get("Access-Control-Max-Age"))
+}
+
+func TestSetOptionHeaders(t *testing.T) {
+	cors := CrossOriginResourceSharing{
+		ExposeHeaders:  []string{"Authorization", "AB-Session"},
+		CookiesAllowed: true,
+	}
+
+	// TEST 1: Success
+	req1 := createDummyRequest()
+	req1.Request.Header.Set("Origin", "https://www.example.io")
+	resp1 := createDummyResponse()
+	cors.setOptionsHeaders(req1, resp1)
+
+	assert.NotEmpty(t, resp1.Header().Get("Access-Control-Allow-Origin"))
+	assert.NotEmpty(t, resp1.Header().Get("Access-Control-Expose-Headers"))
+	assert.NotEmpty(t, resp1.Header().Get("Access-Control-Allow-Credentials"))
+	assert.Equal(t, "https://www.example.io", resp1.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "Authorization,AB-Session", resp1.Header().Get("Access-Control-Expose-Headers"))
+	assert.Equal(t, "true", resp1.Header().Get("Access-Control-Allow-Credentials"))
+}
+
+func TestFilter_ActualRequest(t *testing.T) {
+	cors := CrossOriginResourceSharing{
+		AllowedDomains: []string{"https://www.example.io"},
+		AllowedMethods: []string{"GET", "POST"},
+		AllowedHeaders: []string{"Content-Type", "Accept", "Device-Id"},
+		CookiesAllowed: true,
+		MaxAge:         3600,
+	}
+	filterChain := createDummyFilterChain()
+
+	// TEST 1: Origin allowed
+	req1 := createDummyRequest()
+	req1.Request.Header.Set("Origin", "https://www.example.io")
+	req1.Request.Method = "GET"
+	resp1 := createDummyResponse()
+	cors.Filter(req1, resp1, filterChain)
+
+	assert.NotEmpty(t, resp1.Header().Get("Access-Control-Allow-Origin"))
+	assert.NotEmpty(t, resp1.Header().Get("Access-Control-Allow-Credentials"))
+	assert.Empty(t, resp1.Header().Get("Access-Control-Allow-Methods"))
+	assert.Empty(t, resp1.Header().Get("Access-Control-Allow-Headers"))
+	assert.Empty(t, resp1.Header().Get("Access-Control-Max-Age"))
+
+	assert.Equal(t, "https://www.example.io", resp1.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "true", resp1.Header().Get("Access-Control-Allow-Credentials"))
+
+	// TEST 2: Origin is not allowed
+	req2 := createDummyRequest()
+	req2.Request.Header.Set("Origin", "https://wrong.accelbyte.io")
+	req2.Request.Method = "GET"
+	resp2 := createDummyResponse()
+	cors.Filter(req2, resp2, filterChain)
+
+	assert.Empty(t, resp2.Header().Get("Access-Control-Allow-Origin"))
+	assert.Empty(t, resp2.Header().Get("Access-Control-Allow-Credentials"))
+	assert.Empty(t, resp2.Header().Get("Access-Control-Allow-Methods"))
+	assert.Empty(t, resp2.Header().Get("Access-Control-Allow-Headers"))
+	assert.Empty(t, resp2.Header().Get("Access-Control-Max-Age"))
+
+	// TEST 3: Origin is not exist in request header
+	req3 := createDummyRequest()
+	req3.Request.Header.Set("Origin", "")
+	req3.Request.Method = "GET"
+	resp3 := createDummyResponse()
+	cors.Filter(req3, resp3, filterChain)
+
+	assert.Empty(t, resp3.Header().Get("Access-Control-Allow-Origin"))
+	assert.Empty(t, resp3.Header().Get("Access-Control-Allow-Credentials"))
+	assert.Empty(t, resp3.Header().Get("Access-Control-Allow-Methods"))
+	assert.Empty(t, resp3.Header().Get("Access-Control-Allow-Headers"))
+	assert.Empty(t, resp3.Header().Get("Access-Control-Max-Age"))
+}
+
+func TestFilter_PreflightRequest(t *testing.T) {
+	cors := CrossOriginResourceSharing{
+		AllowedDomains: []string{"https://www.example.io"},
+		AllowedMethods: []string{"GET", "POST"},
+		AllowedHeaders: []string{"Content-Type", "Accept", "Device-Id"},
+		CookiesAllowed: true,
+		MaxAge:         3600,
+	}
+	filterChain := createDummyFilterChain()
+
+	// TEST 1: Origin allowed
+	req1 := createDummyRequest()
+	req1.Request.Header.Set("Origin", "https://www.example.io")
+	req1.Request.Header.Set("Access-Control-Request-Method", "GET")
+	req1.Request.Header.Set("Access-Control-Request-Headers", "Content-Type,Accept")
+	req1.Request.Method = "OPTIONS"
+	resp1 := createDummyResponse()
+	cors.Filter(req1, resp1, filterChain)
+
+	assert.NotEmpty(t, resp1.Header().Get("Access-Control-Allow-Origin"))
+	assert.NotEmpty(t, resp1.Header().Get("Access-Control-Allow-Credentials"))
+	assert.NotEmpty(t, resp1.Header().Get("Access-Control-Allow-Methods"))
+	assert.NotEmpty(t, resp1.Header().Get("Access-Control-Allow-Headers"))
+	assert.NotEmpty(t, resp1.Header().Get("Access-Control-Max-Age"))
+
+	assert.Equal(t, "https://www.example.io", resp1.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "true", resp1.Header().Get("Access-Control-Allow-Credentials"))
+	assert.Equal(t, "GET,POST", resp1.Header().Get("Access-Control-Allow-Methods"))
+	assert.Equal(t, "Content-Type,Accept", resp1.Header().Get("Access-Control-Allow-Headers"))
+	assert.Equal(t, "3600", resp1.Header().Get("Access-Control-Max-Age"))
+
+	// TEST 2: Origin not allowed
+	req2 := createDummyRequest()
+	req2.Request.Header.Set("Origin", "https://wrong.accelbyte.io")
+	req2.Request.Header.Set("Access-Control-Request-Method", "GET")
+	req2.Request.Header.Set("Access-Control-Request-Headers", "Content-Type,Accept")
+	req2.Request.Method = "OPTIONS"
+	resp2 := createDummyResponse()
+	cors.Filter(req2, resp2, filterChain)
+
+	assert.Empty(t, resp2.Header().Get("Access-Control-Allow-Origin"))
+	assert.Empty(t, resp2.Header().Get("Access-Control-Allow-Credentials"))
+	assert.Empty(t, resp2.Header().Get("Access-Control-Allow-Methods"))
+	assert.Empty(t, resp2.Header().Get("Access-Control-Allow-Headers"))
+	assert.Empty(t, resp2.Header().Get("Access-Control-Max-Age"))
+
+	// TEST 3: Origin is not exist in request header
+	req3 := createDummyRequest()
+	req3.Request.Header.Set("Origin", "")
+	req3.Request.Method = "GET"
+	resp3 := createDummyResponse()
+	cors.Filter(req3, resp3, filterChain)
+
+	assert.Empty(t, resp3.Header().Get("Access-Control-Allow-Origin"))
+	assert.Empty(t, resp3.Header().Get("Access-Control-Allow-Credentials"))
+	assert.Empty(t, resp3.Header().Get("Access-Control-Allow-Methods"))
+	assert.Empty(t, resp3.Header().Get("Access-Control-Allow-Headers"))
+	assert.Empty(t, resp3.Header().Get("Access-Control-Max-Age"))
+
+	// TEST 4: Preflight Request but not specified "Access-Control-Request-Method" in its header,
+	//         so it will consider as Actual Request
+	req4 := createDummyRequest()
+	req4.Request.Header.Set("Origin", "https://www.example.io")
+	req4.Request.Method = "OPTIONS"
+	resp4 := createDummyResponse()
+	cors.Filter(req4, resp4, filterChain)
+
+	assert.NotEmpty(t, resp4.Header().Get("Access-Control-Allow-Origin"))
+	assert.NotEmpty(t, resp4.Header().Get("Access-Control-Allow-Credentials"))
+	assert.Empty(t, resp4.Header().Get("Access-Control-Allow-Methods"))
+	assert.Empty(t, resp4.Header().Get("Access-Control-Allow-Headers"))
+	assert.Empty(t, resp4.Header().Get("Access-Control-Max-Age"))
+
+	assert.Equal(t, "https://www.example.io", resp4.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "true", resp4.Header().Get("Access-Control-Allow-Credentials"))
+}


### PR DESCRIPTION
These PR contains 2 changes:

1. Fix referer header validation that allow referer with extra wrong domain

    Example of extra wrong domain:
     - Expected: https://www.example.com
     - Referer: https://www.example.com.something.com (PASSED)

2. Add CORS filter that support strict allowed-domain validation

    CORS flow is following this:
    https://www.html5rocks.com/static/images/cors_server_flowchart.png

    Basically it's the cloned version of this [cors_filter.go](https://github.com/emicklei/go-restful/blob/v3/cors_filter.go) from go-restful. But we're not include the regex mechanism when doing  allowed domain validation (to avoid security issue).

    Example:
    - Allowed origin: https://www.example.com
    - Previous implementation: https://www.example.com.something.com (PASSED)
    - Desired implementation: https://www.example.com.something.com (NOT PASSED)


https://accelbyte.atlassian.net/browse/OS-6350