### PR TITLE
chore: Support manually set accesslog's field value for namespace, user_id and client_id

### DIFF
--- a/pkg/logger/log/README.md
+++ b/pkg/logger/log/README.md
@@ -69,3 +69,24 @@ ws.Route(ws.GET("/user/{id}").
     To(func(request *restful.Request, response *restful.Response) {
 }))
 ```
+
+### Manually specify log's field value
+
+We could manually set specific field value via request attribute.
+Please refer to the table below for attribute name of each field.
+
+| Field     | Default Value             | Attribute Name           |
+|-----------|---------------------------|--------------------------|
+| namespace | Extracted from JWT claims | `log.NamespaceAttribute` |
+| user_id   | Extracted from JWT claims | `log.UserIDAttribute`    |
+| client_id | Extracted from JWT claims | `log.ClientIDAttribute`  |
+
+Example: 
+
+```go
+// ... your service logic
+request.SetAttribute(log.NamespaceAttribute, "myNamespace")
+request.SetAttribute(log.UserIDAttribute, "myUserId")
+request.SetAttribute(log.ClientIDAttribute, "myClientId")
+// ... your service logic
+```

--- a/pkg/logger/log/log.go
+++ b/pkg/logger/log/log.go
@@ -18,9 +18,14 @@ import (
 	"github.com/emicklei/go-restful/v3"
 )
 
-const MaskedQueryParams = "MaskedQueryParams"
-const MaskedRequestFields = "MaskedRequestFields"
-const MaskedResponseFields = "MaskedResponseFields"
+const (
+	MaskedQueryParamsAttribute    = "MaskedQueryParams"
+	MaskedRequestFieldsAttribute  = "MaskedRequestFields"
+	MaskedResponseFieldsAttribute = "MaskedResponseFields"
+	UserIDAttribute               = "LogUserId"
+	ClientIDAttribute             = "LogClientId"
+	NamespaceAttribute            = "LogNamespace"
+)
 
 // Option contains attribute options for log functionality
 type Option struct {
@@ -36,13 +41,13 @@ type Option struct {
 func Attribute(option Option) restful.FilterFunction {
 	return func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
 		if option.MaskedQueryParams != "" {
-			req.SetAttribute(MaskedQueryParams, option.MaskedQueryParams)
+			req.SetAttribute(MaskedQueryParamsAttribute, option.MaskedQueryParams)
 		}
 		if option.MaskedRequestFields != "" {
-			req.SetAttribute(MaskedRequestFields, option.MaskedRequestFields)
+			req.SetAttribute(MaskedRequestFieldsAttribute, option.MaskedRequestFields)
 		}
 		if option.MaskedResponseFields != "" {
-			req.SetAttribute(MaskedResponseFields, option.MaskedResponseFields)
+			req.SetAttribute(MaskedResponseFieldsAttribute, option.MaskedResponseFields)
 		}
 		chain.ProcessFilter(req, resp)
 	}


### PR DESCRIPTION
This changes allow us to extend the current capability of Log Viewer when extracting value of `namespace`, `user_id` and `client_id`. Currently it will only extract those field value from  `JWTClaims`.

Example use case:

**1. IAM service's token validation:** It not expose attribute `JWTClaims` in its validation implementation, so we couldn't extract those fields value (namespace, user_id or client_id).
**2. In POST `/token` endpoint**: currently there's no way we could set those fields value (namespace, user_id or client_id) into Log Viewer because we will always extract the value from `JWTClaims`.
