### PR TITLE
feat: PI-1233 add subdomain validation to auth filter init options

### DIFF
--- a/pkg/auth/iam/iam_test.go
+++ b/pkg/auth/iam/iam_test.go
@@ -819,368 +819,39 @@ func TestGetHost(t *testing.T) {
 	}
 }
 
-func TestValidateRefererHeaderWithSubdomainFilteringFlag_SimpleRedirectURI(t *testing.T) {
-	os.Setenv(constant.EnvSubdomainValidationEnabled, "true")
+func TestFilterInitializationOptionsFromEnv_SubdomainValidationEnabled(t *testing.T) {
+	var options *FilterInitializationOptions
 
-	iamClient := &iam.MockClient{
-		Healthy:     true,
-		RedirectURI: "https://example.com",
-	}
-	filter := NewFilter(iamClient)
-
-	testcases := []struct {
-		name          string
-		refererHeader string
-		allowed       bool
-	}{
-		{
-			name:          "normal referer",
-			refererHeader: "https://example.com",
-			allowed:       true,
-		},
-		{
-			name:          "normal referer",
-			refererHeader: "https://www.example.com",
-			allowed:       true,
-		},
-		{
-			name:          "normal referer",
-			refererHeader: "https://www.example.com/admin/path",
-			allowed:       true,
-		},
-		{
-			name:          "normal referer",
-			refererHeader: "https://subdomain.example.com",
-			allowed:       true,
-		},
-		{
-			name:          "normal referer",
-			refererHeader: "https://subdomain.example.com/admin/path",
-			allowed:       true,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://example.net",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "http://example.com",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://www.wrong.com",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://subdomain.wrong.com",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://subdomain.example.com.something.com",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://example.com.something.com",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://examplewww.com",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://www.examplewww.com",
-			allowed:       false,
-		},
-	}
-
-	for _, testcase := range testcases {
-		t.Run(testcase.name, func(t *testing.T) {
-			userTokenClaims, _ := filter.iamClient.ValidateAndParseClaims("dummyToken")
-
-			correctRequest := &restful.Request{
-				Request: &http.Request{
-					Header: map[string][]string{
-						constant.Referer: {testcase.refererHeader},
-					},
-				},
-			}
-
-			actual := filter.validateRefererHeader(correctRequest, userTokenClaims)
-
-			assert.Equal(t, testcase.allowed, actual)
-		})
-	}
-
-	os.Setenv(constant.EnvSubdomainValidationEnabled, "")
+	os.Setenv("SUBDOMAIN_VALIDATION_ENABLED", "true")
+	options = FilterInitializationOptionsFromEnv()
+	assert.Equal(t, true, options.AllowSubdomainMatchRefererHeaderValidation)
+	assert.Equal(t, true, options.SubdomainValidationEnabled)
+	os.Unsetenv("SUBDOMAIN_VALIDATION_ENABLED")
 }
 
-// nolint:paralleltest
-func TestValidateRefererHeaderWithSubdomainFilteringFlag_SimpleRedirectURIContainsWWW(t *testing.T) {
-	os.Setenv(constant.EnvSubdomainValidationEnabled, "true")
-
-	iamClient := &iam.MockClient{
-		Healthy:     true,
-		RedirectURI: "https://www.example.com",
-	}
-	filter := NewFilter(iamClient)
-
-	testcases := []struct {
-		name          string
-		refererHeader string
-		allowed       bool
-	}{
-		{
-			name:          "normal referer",
-			refererHeader: "https://example.com",
-			allowed:       true,
-		},
-		{
-			name:          "normal referer",
-			refererHeader: "https://www.example.com",
-			allowed:       true,
-		},
-		{
-			name:          "normal referer",
-			refererHeader: "https://www.example.com/admin/path",
-			allowed:       true,
-		},
-		{
-			name:          "normal referer",
-			refererHeader: "https://subdomain.example.com",
-			allowed:       true,
-		},
-		{
-			name:          "normal referer",
-			refererHeader: "https://subdomain.example.com/admin/path",
-			allowed:       true,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://example.net",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "http://example.com",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://www.wrong.com",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://subdomain.wrong.com",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://subdomain.example.com.something.com",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://example.com.something.com",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://examplewww.com",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://www.examplewww.com",
-			allowed:       false,
-		},
-	}
-
-	for _, testcase := range testcases {
-		t.Run(testcase.name, func(t *testing.T) {
-			userTokenClaims, _ := filter.iamClient.ValidateAndParseClaims("dummyToken")
-
-			correctRequest := &restful.Request{
-				Request: &http.Request{
-					Header: map[string][]string{
-						constant.Referer: {testcase.refererHeader},
-					},
-				},
-			}
-
-			actual := filter.validateRefererHeader(correctRequest, userTokenClaims)
-
-			assert.Equal(t, testcase.allowed, actual)
-		})
-	}
-
-	os.Setenv(constant.EnvSubdomainValidationEnabled, "")
+func TestFilterInitializationOptionsFromEnv_SubdomainValidationDisabled(t *testing.T) {
+	options := FilterInitializationOptionsFromEnv()
+	assert.Equal(t, false, options.AllowSubdomainMatchRefererHeaderValidation)
+	assert.Equal(t, false, options.SubdomainValidationEnabled)
 }
 
-// nolint:paralleltest
-func TestValidateRefererHeaderWithSubdomainFilteringFlag_RedirectURIContainsPort(t *testing.T) {
-	os.Setenv(constant.EnvSubdomainValidationEnabled, "true")
+func TestFilterInitializationOptionsFromEnv_SubdomainValidationExcludedNamespacesSet(t *testing.T) {
+	var options *FilterInitializationOptions
 
-	iamClient := &iam.MockClient{
-		Healthy:     true,
-		RedirectURI: "https://www.example.com:8080",
-	}
-	filter := NewFilter(iamClient)
+	os.Setenv("SUBDOMAIN_VALIDATION_EXCLUDED_NAMESPACES", "foundations,foundations2,foundations3")
+	options = FilterInitializationOptionsFromEnv()
+	assert.Equal(t, []string{"foundations", "foundations2", "foundations3"}, options.SubdomainValidationExcludedNamespaces)
 
-	testcases := []struct {
-		name          string
-		refererHeader string
-		allowed       bool
-	}{
-		{
-			name:          "normal referer",
-			refererHeader: "https://example.com:8080",
-			allowed:       true,
-		},
-		{
-			name:          "normal referer",
-			refererHeader: "https://www.example.com:8080",
-			allowed:       true,
-		},
-		{
-			name:          "normal referer",
-			refererHeader: "https://www.example.com:8080/admin/path",
-			allowed:       true,
-		},
-		{
-			name:          "normal referer",
-			refererHeader: "https://subdomain.example.com:8080",
-			allowed:       true,
-		},
-		{
-			name:          "normal referer",
-			refererHeader: "https://subdomain.example.com:8080/admin/path",
-			allowed:       true,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://example.com",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://www.example.com:8081",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://subdomain.example.com:8081",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://www.example.com.something.com:8080",
-			allowed:       false,
-		},
-	}
+	os.Setenv("SUBDOMAIN_VALIDATION_EXCLUDED_NAMESPACES", "     foundations,foundations2,foundations3,,,    ")
+	options = FilterInitializationOptionsFromEnv()
+	assert.Equal(t, []string{"foundations", "foundations2", "foundations3"}, options.SubdomainValidationExcludedNamespaces)
 
-	for _, testcase := range testcases {
-		t.Run(testcase.name, func(t *testing.T) {
-			userTokenClaims, _ := filter.iamClient.ValidateAndParseClaims("dummyToken")
-
-			correctRequest := &restful.Request{
-				Request: &http.Request{
-					Header: map[string][]string{
-						constant.Referer: {testcase.refererHeader},
-					},
-				},
-			}
-
-			actual := filter.validateRefererHeader(correctRequest, userTokenClaims)
-
-			assert.Equal(t, testcase.allowed, actual)
-		})
-	}
-
-	os.Setenv(constant.EnvSubdomainValidationEnabled, "")
+	os.Unsetenv("SUBDOMAIN_VALIDATION_EXCLUDED_NAMESPACES")
 }
 
-// nolint:paralleltest
-func TestValidateRefererHeaderWithSubdomainFilteringFlag_RedirectURIIsIP(t *testing.T) {
-	os.Setenv(constant.EnvSubdomainValidationEnabled, "true")
+func TestFilterInitializationOptionsFromEnv_SubdomainValidationExcludedNamespacesEmpty(t *testing.T) {
+	var options *FilterInitializationOptions
 
-	iamClient := &iam.MockClient{
-		Healthy:     true,
-		RedirectURI: "http://127.0.0.1",
-	}
-	filter := NewFilter(iamClient)
-
-	testcases := []struct {
-		name          string
-		refererHeader string
-		allowed       bool
-	}{
-		{
-			name:          "normal referer",
-			refererHeader: "http://127.0.0.1",
-			allowed:       true,
-		},
-		{
-			name:          "normal referer",
-			refererHeader: "http://127.0.0.1/admin/path",
-			allowed:       true,
-		},
-		{
-			name:          "normal referer",
-			refererHeader: "http://subdomain.127.0.0.1",
-			allowed:       true,
-		},
-		{
-			name:          "normal referer",
-			refererHeader: "http://subdomain.127.0.0.1/admin/path",
-			allowed:       true,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "https://example.net",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "http://127.0.0.2",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "http://127.0.0.1.2",
-			allowed:       false,
-		},
-		{
-			name:          "wrong referer",
-			refererHeader: "http://subdomain.127.0.0.2",
-			allowed:       false,
-		},
-	}
-
-	for _, testcase := range testcases {
-		t.Run(testcase.name, func(t *testing.T) {
-			userTokenClaims, _ := filter.iamClient.ValidateAndParseClaims("dummyToken")
-
-			correctRequest := &restful.Request{
-				Request: &http.Request{
-					Header: map[string][]string{
-						constant.Referer: {testcase.refererHeader},
-					},
-				},
-			}
-
-			actual := filter.validateRefererHeader(correctRequest, userTokenClaims)
-
-			assert.Equal(t, testcase.allowed, actual)
-		})
-	}
-
-	os.Setenv(constant.EnvSubdomainValidationEnabled, "")
+	options = FilterInitializationOptionsFromEnv()
+	assert.Empty(t, options.SubdomainValidationExcludedNamespaces)
 }

--- a/pkg/constant/constants.go
+++ b/pkg/constant/constants.go
@@ -15,8 +15,7 @@
 package constant
 
 const (
-	ContentType                   = "Content-Type"
-	Referer                       = "Referer"
-	UserAgent                     = "User-Agent"
-	EnvSubdomainValidationEnabled = "SUBDOMAIN_VALIDATION_ENABLED"
+	ContentType = "Content-Type"
+	Referer     = "Referer"
+	UserAgent   = "User-Agent"
 )


### PR DESCRIPTION
based on a suggestion from Rexy, I move the logic for checking the excluded namespace when doing the subdomain validation to the library.