### PR TITLE
fix: nil pointer exception

### DIFF
--- a/pkg/logger/log/accesslog.go
+++ b/pkg/logger/log/accesslog.go
@@ -233,7 +233,6 @@ func getRequestBody(req *restful.Request, contentType, requestURL string) (strin
 	bodyBytes, err := io.ReadAll(req.Request.Body)
 	if err != nil {
 		logrus.Errorf("failed to read request body: %v", err.Error())
-		return "", 0
 	}
 	if len(bodyBytes) != 0 {
 		// set the original bytes back into request body reader

--- a/pkg/logger/log/accesslog.go
+++ b/pkg/logger/log/accesslog.go
@@ -16,7 +16,7 @@ package log
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -226,17 +226,18 @@ func AccessLog(req *restful.Request, resp *restful.Response, chain *restful.Filt
 
 // getRequestBody will get the request body from Request object
 func getRequestBody(req *restful.Request, contentType, requestURL string) (string, float32) {
-	if contentType == "" || !isSupportedContentType(contentType) {
+	if contentType == "" || !isSupportedContentType(contentType) || req.Request == nil || req.Request.Body == nil {
 		return "", 0
 	}
 
-	bodyBytes, err := ioutil.ReadAll(req.Request.Body)
+	bodyBytes, err := io.ReadAll(req.Request.Body)
 	if err != nil {
 		logrus.Errorf("failed to read request body: %v", err.Error())
+		return "", 0
 	}
 	if len(bodyBytes) != 0 {
 		// set the original bytes back into request body reader
-		req.Request.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
+		req.Request.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 		requestBodySize := len(bodyBytes)
 		requestBodySizeInKB := float32(requestBodySize) / kb


### PR DESCRIPTION
Got panic nil pointer error

```
test panicked: runtime error: invalid memory address or nil pointer dereference
        goroutine 710 [running]:
        runtime/debug.Stack()
        	/usr/local/go/src/runtime/debug/stack.go:24 +0x5e
        github.com/stretchr/testify/suite.failOnPanic(0xc0013a0ea0, {0x1f6b620, 0x3998c10})
        	/opt/go/src/accelbyte.net/justice-session-history-service/vendor/github.com/stretchr/testify/suite/suite.go:87 +0x39
        github.com/stretchr/testify/suite.Run.func1.1()
        	/opt/go/src/accelbyte.net/justice-session-history-service/vendor/github.com/stretchr/testify/suite/suite.go:183 +0x288
        panic({0x1f6b620?, 0x3998c10?})
        	/usr/local/go/src/runtime/panic.go:770 +0x132
        io.ReadAll({0x0, 0x0})
        	/usr/local/go/src/io/io.go:712 +0x55
        io/ioutil.ReadAll(...)
        	/usr/local/go/src/io/ioutil/ioutil.go:27
        github.com/AccelByte/go-restful-plugins/v4/pkg/logger/log.getRequestBody(0xc0008003e0, {0x2273a24, 0x10}, {0xc001390240, 0x35})
        	/opt/go/src/accelbyte.net/justice-session-history-service/vendor/github.com/AccelByte/go-restful-plugins/v4/pkg/logger/log/accesslog.go:233 +0x147
        github.com/AccelByte/go-restful-plugins/v4/pkg/logger/log.AccessLog(0xc0008003e0, 0xc0004f4f50, 0xc0009eca00)
        	/opt/go/src/accelbyte.net/justice-session-history-service/vendor/github.com/AccelByte/go-restful-plugins/v4/pkg/logger/log/accesslog.go:130 +0x2cd
        github.com/emicklei/go-restful/v3.(*FilterChain).ProcessFilter(0xc0013a1040?, 0x295e1c0?, 0xc0013888c0?)
        	/opt/go/src/accelbyte.net/justice-session-history-service/vendor/github.com/emicklei/go-restful/v3/filter.go:21 +0x42
        github.com/emicklei/go-restful/v3.(*Container).dispatch(0xc0007041b0, {0x295e1c0, 0xc0013888c0}, 0xc0013d8360)
        	/opt/go/src/accelbyte.net/justice-session-history-service/vendor/github.com/emicklei/go-restful/v3/container.go:296 +0x9e5
```