### PR TITLE
fix: make a copy of response data in ResponseWriterInterceptor

### DIFF
--- a/pkg/logger/log/responsewriter.go
+++ b/pkg/logger/log/responsewriter.go
@@ -24,6 +24,9 @@ type ResponseWriterInterceptor struct {
 }
 
 func (w *ResponseWriterInterceptor) Write(b []byte) (int, error) {
-	w.data = b
+	if w.data == nil {
+        w.data = make([]byte, len(b))
+        copy(w.data, b)
+    }
 	return w.ResponseWriter.Write(b)
 }


### PR DESCRIPTION
The data in **ResponseWriterInterceptor** will be changed from the beginning of the array, not replaced entirely, making the data not a valid json, it seems that the underlying array of the slice was changed somewhere
![image](https://github.com/user-attachments/assets/9f7bf518-9346-4eba-bfa2-cdff9e8ffcd5)

Debugging: (endpoint: /iam/v4/public/namespaces/{namespace}/users - PublicCreateUserV4)
1. The data in ResponseWriterInterceptor is correct
![image](https://github.com/user-attachments/assets/344420b8-2345-4a07-bc54-5abd76e06193)
2. The data when we get the response body
![image](https://github.com/user-attachments/assets/df6a8725-6c4b-4f53-bfae-270846547fd1)
