### PR TITLE
chore: make insufficient subscription error message more verbose

### DIFF
--- a/pkg/auth/iam/iam.go
+++ b/pkg/auth/iam/iam.go
@@ -706,10 +706,8 @@ func WithValidSubscription(subscription string) FilterOption {
 
 		// Only check IsSubscribed if subscription is not empty
 		if !iamClient.IsSubscribed(claims, subscription) {
-			insufficientSubscriptionMessage := ErrorCodeMapping[InsufficientSubscription]
-
 			return respondError(http.StatusForbidden, InsufficientSubscription,
-				"access forbidden: "+insufficientSubscriptionMessage)
+				"access forbidden: "+ErrorCodeMapping[InsufficientSubscription]+", required subscription: "+subscription+", owned subscription(s): "+strings.Join(claims.Subscriptions, ","))
 		}
 
 		return nil


### PR DESCRIPTION
# Example

subs claims is empty (not `nil`):
<img width="1291" height="201" alt="Screenshot from 2026-01-15 10-40-53" src="https://github.com/user-attachments/assets/e21efacf-cd48-4fb8-9034-d69b2d59c0d1" />

subs claims have insufficient subscription:
<img width="1291" height="201" alt="Screenshot from 2026-01-15 10-40-02" src="https://github.com/user-attachments/assets/d1b220fd-4a45-4053-bf57-bd718c201535" />
