### PR TITLE
chore: allow publisher namespace CORS settings to be used as a global fallback configuration when namespace cannot be identified

### DIFF
--- a/pkg/cors/cors_dynamic_test.go
+++ b/pkg/cors/cors_dynamic_test.go
@@ -496,6 +496,48 @@ func TestNewCrossOriginResourceSharingMissingIAMClient(t *testing.T) {
 	}
 }
 
+func TestGetConfigWithDynamicResolution_FallsBackToPublisherNamespace(t *testing.T) {
+	mockClient := NewMockConfigClient()
+	mockClient.configs["publisher"] = &CORSConfigValue{
+		AllowedDomains: []string{"https://publisher.example.com"},
+		AllowedMethods: []string{"GET", "POST"},
+	}
+
+	filter := &CrossOriginResourceSharing{
+		AllowedDomains:     []string{"https://service.com"},
+		AllowedMethods:     []string{"GET"},
+		ConfigClient:       mockClient,
+		PublisherNamespace: "publisher",
+		subdomainConfig:    &CORSSubdomainConfig{SubdomainEnabled: false},
+		subdomainLoaded:    true,
+	}
+
+	// Request with no namespace in path, subdomain, or header
+	req := &restful.Request{
+		Request: &http.Request{
+			Method: "GET",
+			Header: http.Header{
+				"Origin": []string{"https://publisher.example.com"},
+			},
+			Host: "example.com",
+		},
+	}
+
+	chainCalled := false
+	chain := createTestFilterChain(&chainCalled)
+	resp := &restful.Response{ResponseWriter: httptest.NewRecorder()}
+
+	filter.Filter(req, resp, chain)
+
+	if !chainCalled {
+		t.Error("FilterChain should be called when origin is allowed via publisher namespace config")
+	}
+	if resp.Header().Get("Access-Control-Allow-Origin") != "https://publisher.example.com" {
+		t.Errorf("Expected CORS allow header from publisher namespace config, got %q",
+			resp.Header().Get("Access-Control-Allow-Origin"))
+	}
+}
+
 // TestFilterDoesNotCancelRequestContext is a regression test for the bug where
 // getConfigWithDynamicResolution replaced req.Request with a context that was
 // immediately cancelled via defer cancel(), poisoning all downstream handlers.

--- a/pkg/cors/cors_filter.go
+++ b/pkg/cors/cors_filter.go
@@ -147,7 +147,6 @@ func (c *CrossOriginResourceSharing) isPreflightRequest(req *restful.Request) bo
 	return false
 }
 
-
 // initConfigServiceClient initializes the config service client from ConfigServiceURL.
 // If ConfigServiceURL is empty, dynamic config is disabled and static config is used.
 // IAMClient is required when ConfigServiceURL is set; initialization is skipped with an error log if missing.
@@ -222,6 +221,9 @@ func (c *CrossOriginResourceSharing) getConfigWithDynamicResolution(req *restful
 	c.loadSubdomainConfig()
 	subdomainEnabled, baseDomain := c.getSubdomainSettings()
 	namespace := ExtractNamespace(req, subdomainEnabled, baseDomain)
+	if namespace == "" && c.PublisherNamespace != "" {
+		namespace = c.PublisherNamespace
+	}
 	if namespace == "" {
 		return nil
 	}


### PR DESCRIPTION
The current dynamic CORS behavior **falls back to the service-level CORS configuration only** when no namespace can be extracted (either from the request URL path or from the namespace extracted from the JWT token by the rate limit proxy). This commonly occurs on public endpoints that do not contain namespace information.

As a result, the dynamic CORS feature provides no value from a customer perspective, since customers ultimately need assistance from the Ops team to reconfigure the service-level CORS settings for their use case.

The expected behavior is to fall back to the Publisher CORS configuration when no namespace can be identified, allowing customers to manage the CORS settings themselves through the Publisher configuration.